### PR TITLE
move babel runtime to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,9 +28,9 @@
     "start": "cd examples && npm run serve"
   },
   "dependencies": {
-    "@babel/runtime": "^7.12.5"
   },
   "devDependencies": {
+    "@babel/runtime": "^7.12.5",
     "@babel/cli": "^7.10.5",
     "@babel/core": "^7.12.3",
     "@babel/plugin-proposal-class-properties": "^7.10.4",


### PR DESCRIPTION
把babel-runtime作为 devDependencies，babel-runtime 没有必要作为安装依赖。