### PR TITLE
fix: prevent error on instance destruction before message receipt

### DIFF
--- a/src/message-channel.js
+++ b/src/message-channel.js
@@ -74,7 +74,9 @@ class MessageChannel {
         resolve: reswrap, reject, eventId
       }, method, payload);
       ctimer = setTimeout(() => {
-        delete this.messageResponse[eventId];
+        if (this.messageResponse) {
+          delete this.messageResponse[eventId];
+        }
         reject(new Error('postMessage timeout'));
       }, this.timeout || (20 * 1000));
     });


### PR DESCRIPTION
Modified the timeout function to check if this.messageResponse exists before attempting to delete an item from it. This addresses a bug where destroying the instance before a message was received resulted in a null reference error during the evaluation of "delete this.messageResponse[eventId]". The added conditional ensures stability and error prevention in such scenarios.